### PR TITLE
Fix file reading error when using read_csv and partial schema

### DIFF
--- a/duck_main.py
+++ b/duck_main.py
@@ -5,14 +5,7 @@ t1 = datetime.now()
 conn = duckdb.connect()
 conn.execute("SET experimental_parallel_csv=TRUE")
 conn.execute("""SELECT date, SUM(failure) as failures
-                FROM read_csv('data/*/*.csv', delim=',', header=True,  IGNORE_ERRORS=1, 
-                    columns={
-                            'date': 'DATE',
-                            'serial_number' : 'VARCHAR',
-                            'model' : 'VARCHAR',
-                            'capacity_bytes' : 'VARCHAR',
-                            'failure' : 'INT'
-                            })
+                FROM read_csv_auto('data/*/*.csv', delim=',', header=True,  IGNORE_ERRORS=1)
              GROUP BY date;""")
 print(conn.fetchall())
 t2 = datetime.now()


### PR DESCRIPTION
The DuckDB `group by` query returns incorrect results (when compared to the Polars result). After investigating, it appears that passing a partial schema in the `read_csv` with the `columns` parameters is not supported, and this is skipping rows as the result. 

This test was performed in Google colab with `duckdb-0.6.1` installed using pip.

To get equal results, I changed `read_csv` to `read_csv_auto` to allow automatic columns detection. The total query time is actually slower when reading all possible files after this change.